### PR TITLE
Add a function to terminate an elapsed timer with error

### DIFF
--- a/lib/RequestLogger.js
+++ b/lib/RequestLogger.js
@@ -245,6 +245,22 @@ class RequestLogger {
     }
 
     /**
+     * Logging function to finish an elapsed counter in error level
+     *
+     * @param {string} msg    - The message string to include in the log entry.
+     * @param {object} [data] - The object providing additional JSON fields
+     *                          for the log entry. This is how to provide
+     *                          metadata for a specific log entry.
+     *
+     * @returns {undefined}
+     */
+    errorEnd(msg, data) {
+        assert.strictEqual(this.elapsedTime, null, 'The "end()" logging method '
+                           + 'should not be called more than once.');
+        return this.log('error', msg, data, true);
+    }
+
+    /**
      * This function adds a Log Entry to the logger, and logs it if its level
      * is above the configured logging level. In case the entry's level reaches
      * the dump threshold level, every past entry is dumped before this one,

--- a/tests/unit/RequestLogger.js
+++ b/tests/unit/RequestLogger.js
@@ -309,6 +309,16 @@ describe('RequestLogger', () => {
             assert.strictEqual(typeof(dummyLogger.ops[0][1][0].elapsed_ms), 'number');
             done();
         });
+
+        it('should include an "elapsed_ms" field in the last log entry and be error level', () => {
+            const dummyLogger = new DummyLogger();
+            const reqLogger = new RequestLogger(dummyLogger, 'info', 'fatal', 'info');
+            reqLogger.errorEnd('Last message failed');
+            assert.strictEqual(dummyLogger.ops[0][1][1], 'Last message failed');
+            assert.notStrictEqual(dummyLogger.ops[0][1][0].elapsed_ms, undefined);
+            assert.strictEqual(typeof(dummyLogger.ops[0][1][0].elapsed_ms), 'number');
+            assert.strictEqual(dummyLogger.ops[0][0], 'error');
+        });
     });
 
     describe('Log History dumped when logging floor level reached', () => {


### PR DESCRIPTION
Add a errorEnd() function to terminate properly an elapsed
timer with an error log level
