### PR TITLE
FT: add time field

### DIFF
--- a/lib/RequestLogger.js
+++ b/lib/RequestLogger.js
@@ -436,6 +436,15 @@ class RequestLogger {
         const fields = Object.assign({}, logFields || {});
         const endFlag = isEnd || false;
 
+        /*
+        * Even though this is added automatically by bunyan, it uses an
+        * expensive regex to figure out the native Date function. By adding
+        * timestamp here avoids that expensive call.
+        */
+        if (fields.time === undefined) {
+            fields.time = new Date();
+        }
+
         fields.req_id = serializeUids(this.uids);
         if (endFlag) {
             this.elapsedTime = process.hrtime(this.startTime);


### PR DESCRIPTION
Normally node-bunyan automatically adds this field if it's omitted,
but it uses lodash to generate the timestamp, which in turn uses
a costly regex to figure out if the date method is available in an
env. That particular call was consuming a lot of cpu ticks, sitting
up top on the profiler log.
