### PR TITLE
perf: remove hrtime field

### DIFF
--- a/lib/RequestLogger.js
+++ b/lib/RequestLogger.js
@@ -435,15 +435,7 @@ class RequestLogger {
         }
         const fields = Object.assign({}, logFields || {});
         const endFlag = isEnd || false;
-        const hr = process.hrtime();
 
-        /*
-         * Here, Stringify hrtime for it to stay within a one-liner when piping
-         * the output through bunyan's cli tool.
-         * Then prepend the fields to the argument Array we're preparing for
-         * bunyan
-         */
-        fields.hrtime = JSON.stringify(hr);
         fields.req_id = serializeUids(this.uids);
         if (endFlag) {
             this.elapsedTime = process.hrtime(this.startTime);


### PR DESCRIPTION
Stringifying hrtime proved to be expensive as it was consuming a
lot of cpu ticks in the profiler log.
