### PR TITLE
cleanup: remove babel-eslint dep

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,4 @@
-{ 
-    "parser": "babel-eslint",
+{
     "extends": "airbnb",
     "env": {
         "node": true,


### PR DESCRIPTION
npm run lint fails currently as babel-eslint dependency has been
removed.
