### PR TITLE
perf: replace Object.assign with vanilla looping

### DIFF
--- a/lib/RequestLogger.js
+++ b/lib/RequestLogger.js
@@ -6,6 +6,7 @@ const LogLevel = require('./LogLevel.js');
 const Utils = require('./Utils.js');
 const serializeUids = Utils.serializeUids;
 const generateUid = Utils.generateUid;
+const objectCopy = Utils.objectCopy;
 
 function ensureUidValidity(uid) {
     if (uid.indexOf(':') !== -1) {
@@ -26,7 +27,7 @@ class EndLogger {
                            + ' once.');
         // We can alter current instance, as it won't be usable after this
         // call.
-        this.fields = Object.assign(this.fields, data || {});
+        this.fields = objectCopy(this.fields, data || {});
         return this.logger.log(level, msg, this.fields, true);
     }
 
@@ -45,7 +46,7 @@ class EndLogger {
      */
     addDefaultFields(fields) {
         const oldFields = this.fields;
-        this.fields = Object.assign({}, this.fields, fields);
+        this.fields = objectCopy({}, this.fields, fields);
         return oldFields;
     }
 
@@ -248,7 +249,7 @@ class RequestLogger {
      */
     addDefaultFields(fields) {
         const oldFields = this.fields;
-        this.fields = Object.assign({}, this.fields, fields);
+        this.fields = objectCopy({}, this.fields, fields);
         return oldFields;
     }
 
@@ -433,7 +434,7 @@ class RequestLogger {
                 });
             return;
         }
-        const fields = Object.assign({}, logFields || {});
+        const fields = objectCopy({}, logFields || {});
         const endFlag = isEnd || false;
 
         /*
@@ -484,7 +485,7 @@ class RequestLogger {
      * @returns {undefined}
      */
     doLogIO(logEntry) {
-        const fields = Object.assign({}, this.fields, logEntry.fields);
+        const fields = objectCopy({}, this.fields, logEntry.fields);
 
         switch (logEntry.level) {
         case 'trace':

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -40,8 +40,27 @@ function unserializeUids(stringdata) {
     return stringdata.split(':');
 }
 
+/**
+* This function copies the properties from the source object to the target object
+* @param {...object} target - object to be copied to
+* @returns {object} - target object
+*/
+function objectCopy(target) {
+    const result = target;
+    let source;
+    function copy(f) {
+        result[f] = source[f];
+    }
+    for (let i = 1; i < arguments.length; i++) {
+        source = arguments[i];
+        Object.keys(source).forEach(copy);
+    }
+    return result;
+}
+
 module.exports = {
     generateUid,
     serializeUids,
     unserializeUids,
+    objectCopy,
 };

--- a/tests/unit/Utils.js
+++ b/tests/unit/Utils.js
@@ -5,6 +5,7 @@ const Utils = require('../../lib/Utils.js');
 const generateUid = Utils.generateUid;
 const serializeUids = Utils.serializeUids;
 const unserializeUids = Utils.unserializeUids;
+const objectCopy = Utils.objectCopy;
 
 describe('Utils: generateUid', () => {
     it('generates a string-typed ID', (done) => {
@@ -39,6 +40,28 @@ describe('Utils: serializeUids', () => {
         const refUidList = [ 'FirstUID', 'SecondUID', 'ThirdUID'];
         const unserializedUIDs = unserializeUids('FirstUID:SecondUID:ThirdUID');
         assert.deepStrictEqual(unserializedUIDs, refUidList, 'Unserialized UID List should match expected value.');
+        done();
+    });
+});
+
+describe('Utils: objectCopy', () => {
+    it('copies all the properties from source to target object', (done) => {
+        const target = { foo: 'bar' };
+        const source = { id: 1, name: 'demo', value: { a: 1, b: 2, c: 3 } };
+        const result = { foo: 'bar', id: 1, name: 'demo', value: { a: 1, b: 2, c: 3 } };
+        objectCopy(target, source);
+        assert.deepStrictEqual(target, result, 'target should have the same properties as source');
+        done();
+    });
+
+    it('copies all the properties from multiple sources to target object', (done) => {
+        const target = { foo: 'bar' };
+        const source1 = { id: 1, name: 'demo1', value: { a: 1, b: 2, c: 3 } };
+        const source2 = { req_id: 2, method: 'test', err: { code: 'error', msg: 'test' } };
+        const result = { foo: 'bar', id: 1, name: 'demo1', value: { a: 1, b: 2, c: 3 },
+            req_id: 2, method: 'test', err: { code: 'error', msg: 'test' }};
+        objectCopy(target, source1, source2);
+        assert.deepStrictEqual(target, result, 'target should have the same properties as source');
         done();
     });
 });


### PR DESCRIPTION
Object.assign is currently not very performant, replacing it with standard looping.
