### PR TITLE
FT: safe JSON.stringify

### DIFF
--- a/lib/SimpleLogger.js
+++ b/lib/SimpleLogger.js
@@ -1,5 +1,25 @@
 'use strict';
 const os = require('os');
+const safeJSONStringify = require('safe-json-stringify');
+/*
+* This function safely stringifies JSON. If an exception occcurs (due to
+* circular references, exceptions thrown from object getters etc.), the module
+* safe-json-stringify is used to remove the offending property and return a
+* stringified object. This approach is ideal as it does not tax every log entry
+* to use the module and has been tested using Cosbench to verify that it doesn't
+* introduce any regression in performance.
+*/
+function safeStringify(obj) {
+    let str;
+    try {
+        str = JSON.stringify(obj);
+    } catch (e) {
+        // fallback to remove circular object references or other exceptions
+        obj.unsafeJSON = true;
+        return safeJSONStringify(obj);
+    }
+    return str;
+}
 
 function isWriteableStream(s) {
     if (!s.stream) {
@@ -22,6 +42,8 @@ class SimpleLogger {
             * This is for backwards compatibility. current config in projects
             * create a bunyan-logstash stream which is not a compatible
             * writeable stream. Any non-writable streams will be ignored.
+            * This will be changed to throw an error if non-writable stream is
+            * encountered.
             */
             this.streams = streams.filter(isWriteableStream);
         }
@@ -42,8 +64,9 @@ class SimpleLogger {
         logFields.message = logMsg;
         logFields.hostname = os.hostname();
         logFields.pid = process.pid;
-        const logEntry = JSON.stringify(logFields) + '\n';
-        this.streams.forEach( s => s.stream.write(logEntry));
+
+        this.streams.forEach( s => s.stream
+            .write(safeStringify(logFields) + '\n'));
     }
 
     info(fields, message) {

--- a/licenses/SAFE-JSON-STRINGIFY
+++ b/licenses/SAFE-JSON-STRINGIFY
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 E-conomic
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "url": "https://github.com/scality/werelogs/issues"
   },
   "homepage": "https://github.com/scality/werelogs#readme",
-  "dependencies": {},
+  "dependencies": {
+    "safe-json-stringify": "^1.0.3"
+  },
   "devDependencies": {
     "eslint": "^1.10.1",
     "eslint-config-airbnb": "^1.0.2",


### PR DESCRIPTION
Protects from JSON.stringfy throwing an exception when the object
being stringified has circular references.
I have run cosbench tests using this dependency. It doesn't introduce any performance regression.
Fix #66
