### PR TITLE
refactor(werelogs): export using ES6 standards

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/Logger.js');
+module.exports = { Logger: require('./lib/Logger.js') };

--- a/tests/functional/basic_usage.js
+++ b/tests/functional/basic_usage.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const PassThrough = require('stream').PassThrough;
 const pass = new PassThrough;
 
-const Logger = require('werelogs');
+const Logger = require('werelogs').Logger;
 
 // With PassThrough, SimpleLogger can use it as Writeable stream and all the
 // data being written can be read into a variable

--- a/tests/functional/multi-modules/index.js
+++ b/tests/functional/multi-modules/index.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const PassThrough = require('stream').PassThrough;
 
-const Werelogs = require('werelogs');
+const Werelogs = require('werelogs').Logger;
 const modules = [
     require('./module1.js'),
     require('./module2.js'),

--- a/tests/functional/multi-modules/module1.js
+++ b/tests/functional/multi-modules/module1.js
@@ -1,4 +1,4 @@
-const Werelogs = require('werelogs');
+const Werelogs = require('werelogs').Logger;
 
 const log = new Werelogs('test-mod1');
 

--- a/tests/functional/multi-modules/module2.js
+++ b/tests/functional/multi-modules/module2.js
@@ -1,4 +1,4 @@
-const Werelogs = require('werelogs');
+const Werelogs = require('werelogs').Logger;
 
 const log = new Werelogs('test-mod2');
 

--- a/tests/functional/multi-modules/module3.js
+++ b/tests/functional/multi-modules/module3.js
@@ -1,4 +1,4 @@
-const Werelogs = require('werelogs');
+const Werelogs = require('werelogs').Logger;
 
 const log = new Werelogs('test-mod3');
 

--- a/tests/unit/Logger.js
+++ b/tests/unit/Logger.js
@@ -9,7 +9,7 @@ const DummyLogger = Utils.DummyLogger;
 
 const Config = require('../../lib/Config.js');
 const RequestLogger = require('../../lib/RequestLogger.js');
-const Logger = require('../../index.js');
+const Logger = require('../../index.js').Logger;
 
 /*
  * This function is a thunk-function calling the Utils'  filterGenerator with


### PR DESCRIPTION
Update `index.js` to provide a `Logger` field to match expected
behaviour under ES6 or TypeScript

BREAKING CHANGE