### PR TITLE
Include time in module logger

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -83,7 +83,7 @@ class Logger {
 
     _doLog(levelName, msg, data) {
         const sLogger = Config.logger;
-        const finalData = { name: this.name };
+        const finalData = { name: this.name, time: Date.now() };
         if (!LogLevel.shouldLog(levelName, Config.level)) {
             return;
         }

--- a/tests/unit/Logger.js
+++ b/tests/unit/Logger.js
@@ -41,6 +41,9 @@ function checkFields(src, result) {
             assert.deepStrictEqual(result[k], src[k]);
         }
     });
+    assert.ok(result.hasOwnProperty('time'));
+    // Time field should be current give or take 1s
+    assert.ok((Date.now() - result.time) < 1000);
 }
 
 


### PR DESCRIPTION
The module logger did not include a time field anymore. This change adds it back, making indexed timestamps more precise and less prone to skewing (especially when re-importing logs for offline analysis).

Fix #79