### PR TITLE
SimpleLogger: Call os.hostname() only once

### DIFF
--- a/lib/SimpleLogger.js
+++ b/lib/SimpleLogger.js
@@ -49,6 +49,7 @@ class SimpleLogger {
             */
             this.streams = streams.filter(isWriteableStream);
         }
+        this.hostname = os.hostname();
     }
 
     log(level, fields, message) {
@@ -64,7 +65,7 @@ class SimpleLogger {
         // TODO - Protect these fields from being overwritten
         logFields.level = level;
         logFields.message = logMsg;
-        logFields.hostname = os.hostname();
+        logFields.hostname = this.hostname;
         logFields.pid = process.pid;
 
         this.streams.forEach(s => s.stream


### PR DESCRIPTION
We called os.hostname() each time we log something.
This avoid it.