### PR TITLE
fix: allow upgrading node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "werelogs",
   "engines": {
-     "node": "6.9.5"
+     "node": ">=6.9.5"
   },
   "version": "7.0.0",
   "description": "An efficient raw JSON logging library aimed at micro-services architectures.",


### PR DESCRIPTION
This allows using `yarn` with node versions more recent than the minimum `6.9.5`.