### PR TITLE
Chore: update eslint modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "safe-json-stringify": "^1.0.3"
   },
   "devDependencies": {
-    "eslint-plugin-react": "^4.3.0",
-    "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^6.0.0",
-    "eslint-config-scality": "scality/Guidelines",
+    "eslint": "4.6.0",
+    "eslint-config-airbnb-base": "12.0.0",
+    "eslint-config-scality": "scality/Guidelines#chore/upgradeEslint",
+    "eslint-plugin-import": "2.7.0",
     "istanbul": "^1.0.0-alpha",
     "istanbul-api": "==1.0.0-alpha.9",
     "jsdoc": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "eslint": "4.6.0",
     "eslint-config-airbnb-base": "12.0.0",
-    "eslint-config-scality": "scality/Guidelines#chore/upgradeEslint",
+    "eslint-config-scality": "scality/Guidelines",
     "eslint-plugin-import": "2.7.0",
     "istanbul": "^1.0.0-alpha",
     "istanbul-api": "==1.0.0-alpha.9",


### PR DESCRIPTION
Eslint upgrade will be in 2 steps:
- First add lint changes, drop package version changes and make sure new linter changes are compatible with the old eslint versions.
- Second, add this PR that has the version upgrades and merge after confirming first PR changes convert nicely

This should be merged after https://github.com/scality/werelogs/pull/104