### PR TITLE
impr: WRLGS-8 replace asserts by error logs

### DIFF
--- a/lib/RequestLogger.js
+++ b/lib/RequestLogger.js
@@ -1,8 +1,6 @@
 
 // eslint-disable-line strict
 
-const assert = require('assert');
-
 const LogLevel = require('./LogLevel.js');
 const Utils = require('./Utils.js');
 
@@ -23,9 +21,6 @@ class EndLogger {
     }
 
     augmentedLog(level, msg, data) {
-        assert.strictEqual(this.logger.elapsedTime, null, 'The logger\'s'
-                           + 'end() wrapper should not be called more than'
-                           + ' once.');
         // We can alter current instance, as it won't be usable after this
         // call.
         this.fields = objectCopy(this.fields, data || {});
@@ -370,8 +365,6 @@ class RequestLogger {
         if (msg === undefined && data === undefined) {
             return this.endLogger;
         }
-        assert.strictEqual(this.elapsedTime, null, 'The "end()" logging method '
-                           + 'should not be called more than once.');
         return this.log(this.endLevel, msg, data, true);
     }
 
@@ -388,8 +381,6 @@ class RequestLogger {
      * @returns {undefined}
      */
     errorEnd(msg, data) {
-        assert.strictEqual(this.elapsedTime, null, 'The "end()" logging method '
-                           + 'should not be called more than once.');
         return this.log('error', msg, data, true);
     }
 
@@ -449,6 +440,12 @@ class RequestLogger {
         // eslint-disable-next-line camelcase
         fields.req_id = serializeUids(this.uids);
         if (endFlag) {
+            if (this.elapsedTime !== null) {
+                // reset elapsedTime to avoid an infinite recursion
+                // while logging the error
+                this.elapsedTime = null;
+                this.error('RequestLogger.end() has been called more than once');
+            }
             this.elapsedTime = process.hrtime(this.startTime);
             // eslint-disable-next-line camelcase
             fields.elapsed_ms = this.elapsedTime[0] * 1000

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=10"
   },
-  "version": "8.1.3",
+  "version": "8.1.4",
   "description": "An efficient raw JSON logging library aimed at micro-services architectures.",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/RequestLogger.js
+++ b/tests/unit/RequestLogger.js
@@ -414,6 +414,21 @@ describe('RequestLogger', () => {
             assert.strictEqual(dummyLogger.ops[0][1][0].endValue, 42);
             done();
         });
+
+        it('should log an error in addition to request logs when end() called more than once',
+        done => {
+            const dummyLogger = new DummyLogger();
+            const reqLogger = new RequestLogger(dummyLogger, 'trace', 'fatal');
+            reqLogger.end().info('after first call to end()');
+            reqLogger.end().debug('after second call to end()');
+            assert.strictEqual(dummyLogger.ops.length, 3);
+            assert.strictEqual(dummyLogger.ops[0][0], 'info');
+            assert.strictEqual(dummyLogger.ops[0][1][1], 'after first call to end()');
+            assert.strictEqual(dummyLogger.ops[1][0], 'error');
+            assert.strictEqual(dummyLogger.ops[2][0], 'debug');
+            assert.strictEqual(dummyLogger.ops[2][1][1], 'after second call to end()');
+            done();
+        });
     });
 
     describe('Log History dumped when logging floor level reached', () => {


### PR DESCRIPTION
When RequestLogger.end() was called more than once for a particular RequestLogger, an assert used to be raised, now an error log is dumped instead which doesn't raise an exception and allows the worker to continue processing further requests.

In this case an assert is not warranted because:

- the issue is not critical and doesn't prevent the process from continuing normal processing

- the issue could be triggered from unfrequent code paths that are hard to find by just reading the code.

By logging an error instead, we have a notification of the issue in the process logs, and it helps to spot the root cause when investigating because the 'error' log triggers a dump of the full request trace logs.
